### PR TITLE
Added TextureCoordinates to SpeckleMesh

### DIFF
--- a/SpeckleCore/BaseObjects.cs
+++ b/SpeckleCore/BaseObjects.cs
@@ -815,6 +815,10 @@ namespace SpeckleCore
         [Newtonsoft.Json.JsonProperty("vertices", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public double[] Vertices { get; set; }
 
+        /// <summary>The mesh's UV array, in a flat array (ie, `x1, y1, x2, y2, ...`)</summary>
+        [Newtonsoft.Json.JsonProperty("texture_coordinates", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
+        public double[] TextureCoordinates { get; set; }        
+
         /// <summary>The faces array.</summary>
         [Newtonsoft.Json.JsonProperty("faces", Required = Newtonsoft.Json.Required.Default, NullValueHandling = Newtonsoft.Json.NullValueHandling.Ignore)]
         public int[] Faces { get; set; }

--- a/SpeckleCore/BaseObjectsExtensions.cs
+++ b/SpeckleCore/BaseObjectsExtensions.cs
@@ -364,16 +364,17 @@ namespace SpeckleCore
     {
         public SpeckleMesh() { }
 
-        public SpeckleMesh(double[] vertices, int[] faces, int[] colors, string applicationId = null, Dictionary<string, object> properties = null)
+        public SpeckleMesh(double[] vertices, int[] faces, int[] colors, double[] texture_coords, string applicationId = null, Dictionary<string, object> properties = null)
         {
             this.Vertices = vertices;
             this.Faces = faces;
             this.Colors = colors;
+            this.TextureCoordinates = texture_coords;
             this.ApplicationId = applicationId;
 
             this.Properties = properties;
 
-            SetHashes(JsonConvert.SerializeObject(Vertices) + JsonConvert.SerializeObject(Faces) + JsonConvert.SerializeObject(Colors));
+            SetHashes(JsonConvert.SerializeObject(Vertices) + JsonConvert.SerializeObject(Faces) + JsonConvert.SerializeObject(Colors) + JsonConvert.SerializeObject(TextureCoordinates));
         }
     }
 


### PR DESCRIPTION
As stated, added TextureCoordinates to SpeckleMesh in the same way Vertices are defined. This goes hand-in-hand with the SpeckleRhino pull request.