### PR TITLE
Construct using parameterless constructor.

### DIFF
--- a/SpeckleCore/Converter.cs
+++ b/SpeckleCore/Converter.cs
@@ -210,7 +210,11 @@ namespace SpeckleCore
 
         try
         {
-          myObject = Activator.CreateInstance( type );
+           ConstructorInfo constructor = type.GetConstructor(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic, null, new Type[] { }, null);
+          if (constructor != null)
+            myObject = constructor.Invoke(new object[] { });
+          if(myObject == null)
+            myObject = Activator.CreateInstance( type );
         }
         catch
         {


### PR DESCRIPTION
Using parameterless constructors (if available) when deserializing permits backing fields to be initialized.