### PR TITLE
Handle Scenario when derived class has new overrides

### DIFF
--- a/SpeckleCore/JsonConverters.cs
+++ b/SpeckleCore/JsonConverters.cs
@@ -226,8 +226,12 @@ namespace SpeckleCore
 
             try
             {
-                type = obj[discriminatorName].Value<string>();
-                isSpeckleObject = true;
+                var jObject = obj[discriminatorName];
+                if (jObject != null)
+                {
+                    type = obj[discriminatorName].Value<string>();
+                    isSpeckleObject = true;
+                }
             }
             catch
             {


### PR DESCRIPTION
When searching for a property, an exception is thrown when a derived class overrides the property with the new keyword.  This edit has a proposal to handle this.