### PR TITLE
Dimitrie/fixes

### DIFF
--- a/SpeckleCore/Converter.cs
+++ b/SpeckleCore/Converter.cs
@@ -535,7 +535,6 @@ namespace SpeckleCore
         {
           return new SpeckleNull();
         }
-        //return methods[ 0 ].Invoke( source, new object[ ] { source } ) as SpeckleObject;
       }
 
       // else just continue with the to abstract part

--- a/SpeckleCore/Converter.cs
+++ b/SpeckleCore/Converter.cs
@@ -526,7 +526,16 @@ namespace SpeckleCore
       // if we have a "ToSpeckle" extension method, then invoke that and return its result
       if ( methods.Count > 0 )
       {
-        return methods[ 0 ].Invoke( source, new object[ ] { source } ) as SpeckleObject;
+        try
+        {
+          var obj = methods[ 0 ].Invoke( source, new object[ ] { source } );
+          return obj as SpeckleObject;
+        }
+        catch
+        {
+          return new SpeckleNull();
+        }
+        //return methods[ 0 ].Invoke( source, new object[ ] { source } ) as SpeckleObject;
       }
 
       // else just continue with the to abstract part


### PR DESCRIPTION
`try{}catches` the invoke from serialisation routine in order to avoid rhino ninja crashes; returns a `SpeckleNull` if the direct conversion  method invoked fails.