### PR TITLE
Fix an issue with Attribute types.

### DIFF
--- a/SpeckleCore/Conversion/JsonConverters.cs
+++ b/SpeckleCore/Conversion/JsonConverters.cs
@@ -118,9 +118,9 @@ namespace SpeckleCore
             var customAttributes = System.Reflection.CustomAttributeExtensions.GetCustomAttributes(objectTypeInfo);
 
             var knownTypeAttributes = System.Linq.Enumerable.Where(customAttributes, a => a.GetType().Name == "KnownTypeAttribute");
-            dynamic knownTypeAttribute = System.Linq.Enumerable.SingleOrDefault(knownTypeAttributes, a => IsKnwonTypeTargetType(a, discriminator));
+            Attribute knownTypeAttribute = System.Linq.Enumerable.SingleOrDefault(knownTypeAttributes, a => IsKnownTypeTargetType(a, discriminator));
             if (knownTypeAttribute != null)
-                return knownTypeAttribute.Type;
+                return knownTypeAttribute.TypeId.GetType();
 
             var typeName = objectType.Namespace + "." + discriminator;
             var subtype = System.Reflection.IntrospectionExtensions.GetTypeInfo(objectType).Assembly.GetType(typeName);
@@ -134,9 +134,9 @@ namespace SpeckleCore
             throw new System.InvalidOperationException("Could not find subtype of '" + objectType.Name + "' with discriminator '" + discriminator + "'.");
         }
 
-        private bool IsKnwonTypeTargetType(dynamic attribute, string discriminator)
+        private bool IsKnownTypeTargetType(Attribute attribute, string discriminator)
         {
-            return attribute?.Type.Name == discriminator;
+            return attribute?.TypeId.GetType().Name == discriminator;
         }
 
 


### PR DESCRIPTION
I don't fully understand this. There doesn't seem to be a `Type` property on [`System.Attribute`](https://docs.microsoft.com/en-us/dotnet/api/system.attribute?view=netframework-4.5), so I don't know why it generally works at the moment. Deserialisation didn't work on iOS when compiled through Unity's IL2CPP, but it does with this fix.

I'm not set up to test this with the current Dynamo & Grasshopper builds, and that should probably happen before merging.

Generally, this file seems a bit magic & confusing. Feedback would be welcome.