### PR TITLE
Patch for different SpeckleAbstract objects with the same properties all have the same hash.

### DIFF
--- a/SpeckleCore/Conversion/Converter.cs
+++ b/SpeckleCore/Conversion/Converter.cs
@@ -617,7 +617,7 @@ namespace SpeckleCore
       }
 
       result.Properties = dict;
-      result.Hash = result.GeometryHash = result.GetMd5FromObject( result.Properties );
+      result.Hash = result.GeometryHash = result.GetMd5FromObject(result.GetMd5FromObject(result._assembly) + result.GetMd5FromObject(result._type) + result.GetMd5FromObject(result.Properties));
 
       return result;
     }


### PR DESCRIPTION
Patch for issue #100