### PR TITLE
Patch for unrolling refs targeting Lists

### DIFF
--- a/SpeckleCore/Conversion/Converter.cs
+++ b/SpeckleCore/Conversion/Converter.cs
@@ -423,7 +423,7 @@ namespace SpeckleCore
         }
         if ( s.Contains( "[" ) ) // special handler for lists
         {
-          propSource = ( ( IEnumerable<object> ) propSource ).ToList()[ int.Parse( s.Substring( 1, s.Length - 2 ) ) ];
+          propSource = ( ( IEnumerable ) propSource ).Cast<object>().ToList()[ int.Parse( s.Substring( 1, s.Length - 2 ) ) ];
           continue;
         }
         var propertySource = TryGetProperty( propSource, s );


### PR DESCRIPTION
Step 0: 
- [x] I've  read the [contribution guidelines](https://github.com/speckleworks/SpeckleOrg/blob/master/CONTRIBUTING.md)!

#### Expected Behaviour
SpeckleAbstract refs should unroll even if referring to lists.

#### Actual Behaviour
If the list ref is referring to is a value type and not a reference type (e.g., 'List<int>'), it will return null.

#### Affected Projects
SpeckleCore

#### Proposed Solution (if any)
Convert target to `IEnumerable` and cast to object instead of converting to `IEnumerable<object>`.