### PR TITLE
Moved a call to get types for a referenced assembly into the SafeLoad…

### DIFF
--- a/SpeckleCore/AssemblyCatalogue.cs
+++ b/SpeckleCore/AssemblyCatalogue.cs
@@ -89,10 +89,7 @@ namespace SpeckleCore
               var assembly = SafeLoadAssembly( AppDomain.CurrentDomain, unloadedAssemblyName );
               if ( assembly != null )
               {
-                var res = assembly.GetTypes();
-                var copy = res;
-
-                assemblies.Add( assembly );
+                assemblies.Add(assembly);
               }
             }
           }
@@ -117,7 +114,10 @@ namespace SpeckleCore
     {
       try
       {
-        return domain.Load( assemblyName );
+        var assembly = domain.Load( assemblyName );
+        //Check that types can be loaded and there are no missing references etc
+        var res = assembly.GetTypes();
+        return assembly;
       }
       catch
       {


### PR DESCRIPTION
…Assembly method.

I tried to remove a library from the Structural kit which no other plugin other than SpeckleGSA needs, which SpeckleGSA loads itself anyway - but found that because SpeckleRevit loads all assemblies and tries to get all types in all assemblies, a missing reference causes an uncaught exception to be thrown.

In a similar way to how SpeckleCore swallows exceptions related to the API/SDK libraries of specific applications not being present, I'd like it to ignore any issues with getting types from assemblies.