### PR TITLE
Reverted a line which caused ALL libraries from kits to be explicitly loaded

### DIFF
--- a/SpeckleCore/AssemblyCatalogue.cs
+++ b/SpeckleCore/AssemblyCatalogue.cs
@@ -79,8 +79,7 @@ namespace SpeckleCore
 
           if ( !loadedSpeckleReferencingAssemblyNames.Any( loadedSpeckleReferencingAssemblyName => AssemblyName.ReferenceMatchesDefinition( loadedSpeckleReferencingAssemblyName, unloadedAssemblyName ) ) )
           {
-            //var relfectionLoadAssembly = Assembly.ReflectionOnlyLoadFrom( assemblyPath );
-            var relfectionLoadAssembly = Assembly.LoadFrom( assemblyPath );
+            var relfectionLoadAssembly = Assembly.ReflectionOnlyLoadFrom( assemblyPath );
             var isReferencingCore = relfectionLoadAssembly.IsReferencing( SpeckleAssemblyName );
 
             if ( isReferencingCore )


### PR DESCRIPTION
Hi guys

SpeckleGSA and the conversion library within the SpeckleStructural kit both reference the same file (SpeckleGSAInterfaces.dll) and I'm finding that it is often loaded twice. 
Note: this library doesn't need to be in the SpeckleStructural kit at all - in fact I'll remove it as soon as SpeckleRevit has been updated with the previous SpeckleCore version - but for the next short while SpeckleGSA will need to be able to cope with it.

I have a few workarounds in mind but I thought I might try to cause a change at the root of the issue - I see during kit initialisation that SpeckleCore *used to* load all kit assemblies using a ReflectionOnlyLoadFrom call but it was commented out in favour of a LoadFrom call.

Could we revert it back to being a ReflectionOnlyLoadFrom call?  That would solve my issue.

Can you remember why it was changed in the first place?

Cheers